### PR TITLE
surfaceprops: Fix sound using index zero

### DIFF
--- a/vphysics_jolt/vjolt_surfaceprops.cpp
+++ b/vphysics_jolt/vjolt_surfaceprops.cpp
@@ -98,6 +98,10 @@ JoltPhysicsSurfaceProps::JoltPhysicsSurfaceProps()
 	prop.data.physics.thickness		= 0.0f;
 	prop.data.physics.dampening		= 0.0f;
 	m_SurfaceProps[ "default" ] = prop;
+
+	// Game code uses 0 as invalid index, expects empty string
+	m_SoundStrings.AddString("");
+
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Game code considers 0 the invalid index, expects it to refer to the empty string. Sound strings must start from 1