### PR TITLE
Rename GAME_DESOLATION to GAME_VITAMIN

### DIFF
--- a/vphysics_jolt/compat/branch_overrides.h
+++ b/vphysics_jolt/compat/branch_overrides.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#if defined( GAME_CSGO ) || defined( GAME_DESOLATION )
+#if defined( GAME_CSGO ) || defined( GAME_VITAMIN )
 #define GAME_CSGO_OR_NEWER
 #define override_csgo override
 #define override_not_csgo
@@ -19,7 +19,7 @@
 #define override_not_gmod override
 #endif
 
-#if defined( GAME_CSGO ) || defined( GAME_DESOLATION ) || defined( GAME_PORTAL2 )
+#if defined( GAME_CSGO ) || defined( GAME_VITAMIN ) || defined( GAME_PORTAL2 )
 #define GAME_PORTAL2_OR_NEWER
 #define override_portal2 override
 #define override_not_portal2
@@ -28,7 +28,7 @@
 #define override_not_portal2 override
 #endif
 
-#if defined( GAME_CSGO ) || defined( GAME_DESOLATION ) || defined( GAME_PORTAL2 ) || defined( GAME_L4D2 )
+#if defined( GAME_CSGO ) || defined( GAME_VITAMIN ) || defined( GAME_PORTAL2 ) || defined( GAME_L4D2 )
 #define GAME_L4D2_OR_NEWER
 #define override_l4d2 override
 #define override_not_l4d2
@@ -37,7 +37,7 @@
 #define override_not_l4d2 override
 #endif
 
-#if defined( GAME_CSGO ) || defined( GAME_DESOLATION ) || defined( GAME_PORTAL2 ) || defined( GAME_L4D2 ) || defined( GAME_ASW )
+#if defined( GAME_CSGO ) || defined( GAME_VITAMIN ) || defined( GAME_PORTAL2 ) || defined( GAME_L4D2 ) || defined( GAME_ASW )
 #define GAME_ASW_OR_NEWER
 #define override_asw override
 #define override_not_asw
@@ -46,7 +46,7 @@
 #define override_not_asw override
 #endif
 
-#ifndef GAME_DESOLATION
+#ifndef GAME_VITAMIN
 using strlen_t = int;
 #endif
 

--- a/vphysics_jolt/vjolt_interface.h
+++ b/vphysics_jolt/vjolt_interface.h
@@ -11,7 +11,7 @@
 // Whether to use the VPhysics debug overlay (legacy compatible) or the fully featured IVDebugOverlay
 // In Desolation, IVDebugOverlay has new members that allow us to draw IMesh objects, without this
 // debugoverlay rendering is incredibly inefficient (and may run the materialsystem mempool out of memory)
-#if !defined( GAME_DESOLATION ) || defined( BUILD_FOR_EXTERNAL_GAME )
+#if !defined( GAME_VITAMIN ) || defined( BUILD_FOR_EXTERNAL_GAME )
 #define VJOLT_USE_PHYSICS_DEBUG_OVERLAY
 #endif
 


### PR DESCRIPTION
We cannot pollute `source_base.vpc` with `GAME_DESOLATION` in non-Desolation games or it's going to get messy. Hammer++ uses `GAME_VITAMIN` so that's what we'll use everywhere.